### PR TITLE
Replaces Windows backslash with Unix forwardslash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Visual Studio Code settings
+/.vscode/

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -6,7 +6,12 @@ console.log("Cleaning library...")
 rmSync("library", { recursive: true, force: true })
 
 console.log("Compiling Typescript...")
-exec("node_modules/.bin/tsc", error => {
+
+const tscPath = process.platform === "win32"
+	? "node_modules\\.bin\\tsc"
+	: "node_modules/.bin/tsc";
+
+exec(tscPath, error => {
 	if (error) console.error(error)
 	else {
 		console.log("Patching imports...")

--- a/source/utilities/patchJsImports.ts
+++ b/source/utilities/patchJsImports.ts
@@ -12,7 +12,7 @@ const resolve = (dependency: string, directory: string) =>
 const relative = (directory: string, path: string) =>
 	relativePath(directory, path).split(sep).join(posix.sep); 
 
-const NODE_MODULES_DIR_TEST = /(^|\/)node_modules(\/|$)/;
+const NODE_MODULES_DIR_REGEX = /(^|\/)node_modules(\/|$)/;
 
 /**
  * When Typescript compiles dependencies, it adds no '.js' extension at the end of imports.
@@ -45,7 +45,7 @@ export default function patchJsImports(
 					let path = resolve(imported, directory);
 
 					if (path != imported) {
-						const isNodeModulePath = NODE_MODULES_DIR_TEST.test(path);
+						const isNodeModulePath = NODE_MODULES_DIR_REGEX.test(path);
 						if (isNodeModulePath) path = imported
 						else {
 							path = relative(directory, path);

--- a/source/utilities/patchJsImports.ts
+++ b/source/utilities/patchJsImports.ts
@@ -8,6 +8,8 @@ const require = createRequire(process.cwd())
 const resolve = (dependency: string, directory: string) =>
 	require.resolve(dependency, { paths: [directory] })
 
+const NODE_MODULES_DIRECTORY = "node_modules";
+
 /**
  * When Typescript compiles dependencies, it adds no '.js' extension at the end of imports.
  * The problem is: browser, Node and Deno all need this '.js' extension.
@@ -39,11 +41,10 @@ export default function patchJsImports(
 					let path = resolve(imported, directory)
 
 					if (path != imported) {
-						const nodeModulesDirectory = "node_modules/"
-						const nodeModulesIndex = path.lastIndexOf(nodeModulesDirectory)
+						const nodeModulesIndex = path.lastIndexOf(NODE_MODULES_DIRECTORY)
 						if (~nodeModulesIndex) path = imported
 						else {
-							path = relative(directory, path)
+							path = relative(directory, path).replace(/\\/g, "/");
 							if (path[0] != "." && path[0] != "/") path = "./" + path
 						}
 					}

--- a/source/utilities/patchJsImports.ts
+++ b/source/utilities/patchJsImports.ts
@@ -1,16 +1,16 @@
 import { readdirSync, statSync, readFileSync, writeFileSync } from "fs"
 import addJsExtensions from "./addJsExtensions"
-import { relative as relativePath, resolve as resolvePath } from "path"
+import { relative as relativePath, resolve as resolvePath, sep, posix } from "path"
 import { createRequire } from "module"
 import { AliasResolver, resolveAliases } from "./resolveAliases"
 
 const require = createRequire(process.cwd())
 
 const resolve = (dependency: string, directory: string) =>
-	require.resolve(dependency, { paths: [directory] }).replace(/\\/g, "/");
+	require.resolve(dependency, { paths: [directory] }).split(sep).join(posix.sep);
 
 const relative = (directory: string, path: string) =>
-	relativePath(directory, path).replace(/\\/g, "/"); 
+	relativePath(directory, path).split(sep).join(posix.sep); 
 
 const NODE_MODULES_DIR_TEST = /(^|\/)node_modules(\/|$)/;
 


### PR DESCRIPTION
I've also removed the "/" from the end of the NODE_MODULES_DIRECTORY because "resolve" returns a string with backslashes on windows, which it wasn't matching.